### PR TITLE
Several bugfixes

### DIFF
--- a/Source/CrewQueue.cs
+++ b/Source/CrewQueue.cs
@@ -60,12 +60,12 @@ namespace CrewRandR
         {
             DontDestroyOnLoad(this);
             _Instance = this;
-            GameEvents.OnVesselRecoveryRequested.Add(OnVesselRecoveryRequested);
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
             // GameEvents.onLevelWasLoaded.Add(OnLevelWasLoaded);
         }
 
         // KSP Events
-        void OnVesselRecoveryRequested(Vessel vessel)
+        void OnVesselRecovered(ProtoVessel vessel, bool quick)
         {
             foreach (ProtoCrewMember kerbal in vessel.GetVesselCrew())
             {

--- a/Source/CrewQueueRoster.cs
+++ b/Source/CrewQueueRoster.cs
@@ -138,6 +138,13 @@ namespace CrewRandR
             {
                 kerbal.rosterStatus = CrewRandR.ROSTERSTATUS_VACATION;
             }
+
+            if (CrewAssignmentDialog.Instance == null)
+            {
+                Logging.Info("CrewAssignmentDialog.Instance is null");
+                return;
+            }
+            Logging.Info("CrewAssignmentDialog.Instance.RefreshCrewLists");
             CrewAssignmentDialog.Instance.RefreshCrewLists( CrewAssignmentDialog.Instance.GetManifest(), true, true);
         }
 

--- a/Source/CrewQueueRoster.cs
+++ b/Source/CrewQueueRoster.cs
@@ -275,7 +275,6 @@ namespace CrewRandR
             Logging.Debug("RosterExtensions.SetLastMissionData");
             CrewRandRRoster.Instance.GetExtForKerbal(kerbal).LastMissionDuration = newMissionDuration;
             CrewRandRRoster.Instance.GetExtForKerbal(kerbal).LastMissionEndTime = currentTime;
-            GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
         }
 
         public static double GetLastMissionDuration(this ProtoCrewMember kerbal)

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -29,6 +29,7 @@ using System.Text;
 using System.Reflection;
 
 using UnityEngine;
+using KSP.UI;
 using KSP.UI.Screens;
 using KSPPluginFramework;
 using FingerboxLib;
@@ -44,6 +45,7 @@ namespace CrewRandR.Interface
         protected override void Awake()
         {
             base.Awake();
+            GameEvents.onEditorStarted.Add(OnEditorStarted);
             GameEvents.onEditorPodPicked.Add(OnEditorPodPicked);
             GameEvents.onEditorLoad.Add(OnEditorLoad);
             GameEvents.onEditorScreenChange.Add(OnEditorScreenChanged);
@@ -56,6 +58,16 @@ namespace CrewRandR.Interface
         }
 #endif
         // KSP Events
+        protected void OnEditorStarted()
+        {
+            // If there's a ship design left over from a previous editor
+            // session, it may have assigned crew who are now on vacation.
+            if (CrewAssignmentDialog.Instance?.GetManifest() != null)
+            {
+                rootNeedsCleaning = true;
+            }
+        }
+
         protected void OnEditorPodPicked(Part part)
         {
             // There's now a root part, and it needs to be cleaned.

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -29,6 +29,7 @@ using System.Text;
 using System.Reflection;
 
 using UnityEngine;
+using KSP.UI.Screens;
 using KSPPluginFramework;
 using FingerboxLib;
 
@@ -44,6 +45,9 @@ namespace CrewRandR.Interface
         {
             base.Awake();
             GameEvents.onEditorShipModified.Add(OnEditorShipModified);
+            GameEvents.onEditorPodDeleted.Add(OnEditorPodDeleted);
+            GameEvents.onEditorRestart.Add(OnEditorRestart);
+            GameEvents.onEditorLoad.Add(OnEditorLoad);
             GameEvents.onEditorScreenChange.Add(OnEditorScreenChanged);
         }
 #if false
@@ -57,6 +61,30 @@ namespace CrewRandR.Interface
         protected void OnEditorShipModified(ShipConstruct ship)
         {
             rootExists = CheckRoot(ship);                       
+        }
+
+        protected void OnEditorPodDeleted()
+        {
+            // Deleting the root part doesn't fire OnEditorShipModified, but
+            // there's no root part anymore.
+            rootExists = false;
+        }
+
+        protected void OnEditorRestart()
+        {
+            // Clicking the editor's "New" button doesn't fire
+            // OnEditorShipModified, but there's no root part anymore.
+            rootExists = false;
+        }
+
+        protected void OnEditorLoad(ShipConstruct ship, CraftBrowserDialog.LoadType loadType)
+        {
+            if (loadType == CraftBrowserDialog.LoadType.Normal)
+            {
+                // Loading a new ship design replaces the root part, and the new
+                // root hasn't been cleaned even if the old one had been.
+                cleanedRoot = false;
+            }
         }
 
         protected void OnEditorScreenChanged(EditorScreen screen)

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -88,21 +88,18 @@ namespace CrewRandR.Interface
         // Our methods
         protected override void Update()
         {
-            if (CrewRandRSettings.Instance != null && CrewRandRSettings.Instance.AssignCrews)
+            try
             {
-                try
+                if (rootNeedsCleaning)
                 {
-                    if (rootNeedsCleaning)
-                    {
-                        CleanManifest();
-                        rootNeedsCleaning = false;
-                    }
+                    CleanManifest();
+                    rootNeedsCleaning = false;
                 }
-                catch (Exception)
-                {
-                    // No worries!
-                    Logging.Debug("If there is a problem with clearing the roster, look here.");
-                }
+            }
+            catch (Exception)
+            {
+                // No worries!
+                Logging.Debug("If there is a problem with clearing the roster, look here.");
             }
         }
     }

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -44,7 +44,7 @@ namespace CrewRandR.Interface
         protected override void Awake()
         {
             base.Awake();
-            GameEvents.onEditorShipModified.Add(OnEditorShipModified);
+            GameEvents.onEditorPodPicked.Add(OnEditorPodPicked);
             GameEvents.onEditorPodDeleted.Add(OnEditorPodDeleted);
             GameEvents.onEditorRestart.Add(OnEditorRestart);
             GameEvents.onEditorLoad.Add(OnEditorLoad);
@@ -58,22 +58,22 @@ namespace CrewRandR.Interface
         }
 #endif
         // KSP Events
-        protected void OnEditorShipModified(ShipConstruct ship)
+        protected void OnEditorPodPicked(Part part)
         {
-            rootExists = CheckRoot(ship);                       
+            // There's now a root part, and it needs to be cleaned.
+            rootExists = true;
+            cleanedRoot = false;
         }
 
         protected void OnEditorPodDeleted()
         {
-            // Deleting the root part doesn't fire OnEditorShipModified, but
-            // there's no root part anymore.
+            // There's no root part anymore.
             rootExists = false;
         }
 
         protected void OnEditorRestart()
         {
-            // Clicking the editor's "New" button doesn't fire
-            // OnEditorShipModified, but there's no root part anymore.
+            // There's no root part anymore.
             rootExists = false;
         }
 
@@ -83,6 +83,7 @@ namespace CrewRandR.Interface
             {
                 // Loading a new ship design replaces the root part, and the new
                 // root hasn't been cleaned even if the old one had been.
+                rootExists = true;
                 cleanedRoot = false;
             }
         }
@@ -123,11 +124,6 @@ namespace CrewRandR.Interface
                     Logging.Debug("If there is a problem with clearing the roster, look here.");
                 }
             }
-        }
-
-        protected bool CheckRoot(ShipConstruct ship)
-        {
-            return (ship != null) && (ship.Count > 0);
         }
     }
 }

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -38,15 +38,13 @@ namespace CrewRandR.Interface
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     class EditorModule : SceneModule
     {
-        bool rootExists, cleanedRoot;
+        bool rootNeedsCleaning = false;
 
         // Monobehaviour Methods
         protected override void Awake()
         {
             base.Awake();
             GameEvents.onEditorPodPicked.Add(OnEditorPodPicked);
-            GameEvents.onEditorPodDeleted.Add(OnEditorPodDeleted);
-            GameEvents.onEditorRestart.Add(OnEditorRestart);
             GameEvents.onEditorLoad.Add(OnEditorLoad);
             GameEvents.onEditorScreenChange.Add(OnEditorScreenChanged);
         }
@@ -61,20 +59,7 @@ namespace CrewRandR.Interface
         protected void OnEditorPodPicked(Part part)
         {
             // There's now a root part, and it needs to be cleaned.
-            rootExists = true;
-            cleanedRoot = false;
-        }
-
-        protected void OnEditorPodDeleted()
-        {
-            // There's no root part anymore.
-            rootExists = false;
-        }
-
-        protected void OnEditorRestart()
-        {
-            // There's no root part anymore.
-            rootExists = false;
+            rootNeedsCleaning = true;
         }
 
         protected void OnEditorLoad(ShipConstruct ship, CraftBrowserDialog.LoadType loadType)
@@ -83,8 +68,7 @@ namespace CrewRandR.Interface
             {
                 // Loading a new ship design replaces the root part, and the new
                 // root hasn't been cleaned even if the old one had been.
-                rootExists = true;
-                cleanedRoot = false;
+                rootNeedsCleaning = true;
             }
         }
 
@@ -108,14 +92,10 @@ namespace CrewRandR.Interface
             {
                 try
                 {
-                    if (rootExists && !cleanedRoot)
+                    if (rootNeedsCleaning)
                     {
                         CleanManifest();
-                        cleanedRoot = true;
-                    }
-                    else if (!rootExists && cleanedRoot)
-                    {
-                        cleanedRoot = false;
+                        rootNeedsCleaning = false;
                     }
                 }
                 catch (Exception)

--- a/Source/Interface/EditorModule.cs
+++ b/Source/Interface/EditorModule.cs
@@ -39,7 +39,7 @@ namespace CrewRandR.Interface
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     class EditorModule : SceneModule
     {
-        bool rootNeedsCleaning = false;
+        bool manifestNeedsCleaning = false;
 
         // Monobehaviour Methods
         protected override void Awake()
@@ -64,14 +64,14 @@ namespace CrewRandR.Interface
             // session, it may have assigned crew who are now on vacation.
             if (CrewAssignmentDialog.Instance?.GetManifest() != null)
             {
-                rootNeedsCleaning = true;
+                manifestNeedsCleaning = true;
             }
         }
 
         protected void OnEditorPodPicked(Part part)
         {
             // There's now a root part, and it needs to be cleaned.
-            rootNeedsCleaning = true;
+            manifestNeedsCleaning = true;
         }
 
         protected void OnEditorLoad(ShipConstruct ship, CraftBrowserDialog.LoadType loadType)
@@ -80,7 +80,7 @@ namespace CrewRandR.Interface
             {
                 // Loading a new ship design replaces the root part, and the new
                 // root hasn't been cleaned even if the old one had been.
-                rootNeedsCleaning = true;
+                manifestNeedsCleaning = true;
             }
         }
 
@@ -102,10 +102,10 @@ namespace CrewRandR.Interface
         {
             try
             {
-                if (rootNeedsCleaning)
+                if (manifestNeedsCleaning)
                 {
                     CleanManifest();
-                    rootNeedsCleaning = false;
+                    manifestNeedsCleaning = false;
                 }
             }
             catch (Exception)

--- a/Source/Interface/SceneModule.cs
+++ b/Source/Interface/SceneModule.cs
@@ -52,17 +52,22 @@ namespace CrewRandR.Interface
 
                 if (partCrewManifests != null && partCrewManifests.Count > 0)
                 {
-                    PartCrewManifest partManifest = partCrewManifests[0];
-                    foreach (ProtoCrewMember crewMember in partManifest.GetPartCrew())
+                    // Remove all crew from the vessel (all parts).
+                    foreach (PartCrewManifest partManifest in partCrewManifests)
                     {
-                        if (crewMember != null)
+                        foreach (ProtoCrewMember crewMember in partManifest.GetPartCrew())
                         {
-                            // Clean the root part
-                            partManifest.RemoveCrewFromSeat(partManifest.GetCrewSeat(crewMember));
+                            if (crewMember != null)
+                            {
+                                partManifest.RemoveCrewFromSeat(partManifest.GetCrewSeat(crewMember));
+                            }
                         }
                     }
+
+                    // Assign fresh crew to the root part.
                     if (CrewRandRSettings.Instance != null && CrewRandRSettings.Instance.AssignCrews)
                     {
+                        PartCrewManifest partManifest = partCrewManifests[0];
                         partManifest.AddCrewToOpenSeats(CrewRandR.Instance.GetCrewForPart(partManifest.PartInfo.partPrefab, new List<ProtoCrewMember>(), true));
                     }
                 }

--- a/Source/Interface/SpaceCenterModule.cs
+++ b/Source/Interface/SpaceCenterModule.cs
@@ -70,23 +70,15 @@ namespace CrewRandR.Interface
                 if (updateCnt-- <= 0)
                     updateLabelOnce = false;
 
-                Logging.Debug("AC is spawned...");
-                AstronautComplex ac = GameObject.FindObjectOfType<AstronautComplex>();
-                if (ac)
+                Logging.Info("");
+                IEnumerable<CrewListItem> crewItemContainers = GameObject.FindObjectsOfType<CrewListItem>().Where(x => x.GetCrewRef().rosterStatus == ProtoCrewMember.RosterStatus.Available);
+                foreach (CrewListItem crewContainer in crewItemContainers)
                 {
-                    foreach (var s in ac.ScrollListAvailable)
+                    if (crewContainer.GetCrewRef().VacationExpiry() - Planetarium.GetUniversalTime() > 0)
                     {
-                        Logging.Info("");
-                        IEnumerable<CrewListItem> crewItemContainers = GameObject.FindObjectsOfType<CrewListItem>().Where(x => x.GetCrewRef().rosterStatus == ProtoCrewMember.RosterStatus.Available);
-                        foreach (CrewListItem crewContainer in crewItemContainers)
-                        {
-                            if (crewContainer.GetCrewRef().VacationExpiry() - Planetarium.GetUniversalTime() > 0)
-                            {
-                                Logging.Debug("relabeling: " + crewContainer.GetName());
-                                string label = "Ready In: " + Utilities.GetFormattedTime(crewContainer.GetCrewRef().VacationExpiry() - Planetarium.GetUniversalTime());
-                                crewContainer.SetLabel(label);
-                            }
-                        }
+                        Logging.Debug("relabeling: " + crewContainer.GetName());
+                        string label = "Ready In: " + Utilities.GetFormattedTime(crewContainer.GetCrewRef().VacationExpiry() - Planetarium.GetUniversalTime());
+                        crewContainer.SetLabel(label);
                     }
                 }
             }


### PR DESCRIPTION
Here are some fixes for a few bugs that I noticed while playing:

* Fixed kerbals not going on vacation if recovered from the tracking station or space center scenes.
* Fixed vacationing kerbals sometimes being auto-assigned as crew in the VAB/SPH.
* Fixed NullReferenceException after clicking on the launchpad or runway at the space center.
* Reduced some brief logspam when opening the astronaut center.

However, to fix the recovery bug, I had to remove a line of code that was added back in the KSP 1.0 days as a workaround for some other bug back then.  It's not clear what that old bug *was*, but I haven't been able to find any problems with the line removed, so I suspect the workaround is no longer needed.  (See commit 3133267d4b15e6c18cc5ae4a5866e79f8902ca54 for the old workaround, its parent fc485f6805c88f8858a98e201e3afadcc6b0f04c, and the comments on my commit c83891dbe6256406794da9e8ebe16d059061189a which removed it.)