### PR TITLE
 Track mission time by kerbal, not by vessel

### DIFF
--- a/Source/CrewQueue.cs
+++ b/Source/CrewQueue.cs
@@ -69,7 +69,7 @@ namespace CrewRandR
         {
             foreach (ProtoCrewMember kerbal in vessel.GetVesselCrew())
             {
-                kerbal.SetLastMissionData(vessel.missionTime, Planetarium.GetUniversalTime());
+                kerbal.SetMissionFinished(Planetarium.GetUniversalTime());
             }
         }
 

--- a/Source/CrewQueueRoster.cs
+++ b/Source/CrewQueueRoster.cs
@@ -59,7 +59,7 @@ namespace CrewRandR
         {
             get
             {
-                return _ExtDataSet.Where(x => x.ProtoReference != null);
+                return _ExtDataSet.Where(x => x.EligibleForVacation);
             }
         }
 
@@ -211,6 +211,16 @@ namespace CrewRandR
                 get
                 {
                     return VacationExpiry > Planetarium.GetUniversalTime() ? true : false;
+                }
+            }
+
+            public bool EligibleForVacation
+            {
+                get
+                {
+                    // Some kerbals (e.g. tourists) aren't considered crew, and
+                    // should be exempt from all CrewRandR handling.
+                    return ProtoReference != null;
                 }
             }
 


### PR DESCRIPTION
When a kerbal goes on R&R, the length of their vacation is based on how long they were away on their mission.  Until now, the recovered vessel's mission elapsed time was used to compute the vacation time for the kerbals inside, but that can be incorrect if a kerbal leaves Kerbin in one vessel but returns in another, or if the vessel's MET gets reset by docking.  To avoid that problem, I've changed it to keep track of mission durations for the kerbals themselves.  When the player places a vessel on the launchpad/runway, the current time gets recorded in the mission data for each kerbal inside.  When the kerbals are recovered later, that starting time is used to calculate how long they were away.

When the player installs this new version, they may have kerbals who are already out on missions and whose mission start time wasn't recorded.  Those kerbals will be considered to have started their missions at the moment when the player first enters the flight scene after installing.  This can cause the kerbals to get shorter vacations than they "ought" to, but only because there's no way to determine the real mission duration in that case.  Newly-launched missions will track the kerbals' mission times correctly going forward.

This fixes #7.